### PR TITLE
Added possibility to specify a maximum number of jobs on batch

### DIFF
--- a/Manager.py
+++ b/Manager.py
@@ -39,8 +39,10 @@ class pidWatcher(object):
             print 'Going to wait for 5 minutes, lets see if condor_q will start to work again.'
             time.sleep(300)
             return
+        ListOfPids = [subInfo[k].arrayPid for k in range(len(subInfo))]
+        if(any(i==-1 for i in ListOfPids)):
+            self.parserWorked=False
         if self.parserWorked:
-            ListOfPids = [subInfo[k].arrayPid for k in range(len(subInfo))]
             # adding Pids of resubmitted jobs
             for process in subInfo:
                 for pid in process.pids:

--- a/Manager.py
+++ b/Manager.py
@@ -337,8 +337,7 @@ class JobManager(object):
                 print 'Adjust the jobsplitting or try again, once you have fewer jobs on HTCondor.'
                 print 'Nothing will be (re-)submitted at this moment.'
                 return False
-            else:
-                return True
+        return True
 
 #class to take care of merging (maybe rethink design)
 class MergeManager(object):

--- a/io_func.py
+++ b/io_func.py
@@ -132,6 +132,7 @@ class fileheader(object):
         self.AutoResubmit =0
         self.MaxJobsPerProcess = -1
         self.RemoveEmptyFileSplit = False
+        self.BatchJobLimit = 5000
         while '<JobConfiguration' not in line:
             self.header.append(line)
             line = f.readline()
@@ -145,6 +146,8 @@ class fileheader(object):
                     self.MaxJobsPerProcess = int(self.ConfigParse.attributes['MaxJobsPerProcess'].value)
                 if self.ConfigParse.hasAttribute('RemoveEmptyFileSplit'):
                     self.RemoveEmptyFileSplit = bool(self.ConfigParse.attributes['RemoveEmptyFileSplit'].value)
+                if self.ConfigParse.hasAttribute('BatchJobLimit'):
+                    self.BatchJobLimit = int(self.ConfigParse.attributes['BatchJobLimit'].value)
 
             if 'ConfigSGE' in line:
                 self.ConfigSGE = parseString(line).getElementsByTagName('ConfigSGE')[0]
@@ -298,7 +301,3 @@ def result_info(Job, path, header, other = []):
     outfile.close()
     
     return 1
-
-
-
-


### PR DESCRIPTION
This adds the possibility to add the option `BatchJobLimit=XXX` (in the `ConfigParse` section of the xml) to specify a maximum number of jobs the user is allowed to submit to HTCondor (its default is 5000 at the moment).

The Manager Class checks how many jobs the user has currently in running/idle/hold status before trying to (re-)submit additional jobs and exits, once the total number would exceed the specified limit.