### PR TITLE
autoResubmission now sets status of process back to working

### DIFF
--- a/Manager.py
+++ b/Manager.py
@@ -217,6 +217,7 @@ class JobManager(object):
                     #print 'resubmitting', process.name+'_'+str(it+1),es not Found',process.notFoundCounter[it], 'pid', process.pids[it], process.arrayPid, 'task',it+1
                     waitingFlag_autoresub = True
                     process.pids[it] = resubmit(self.outputstream+process.name,process.name+'_'+str(it+1),self.workdir,self.header)
+                    process.status = 0
                     #print 'AutoResubmitted job',process.name,it, 'pid', process.pids[it]
                     self.printString.append('File Found '+str(os.path.exists(filename)))
                     if os.path.exists(filename): self.printString.append('Timestamp is ok '+str(process.startingTime < os.path.getctime(filename)))


### PR DESCRIPTION
If you submitted jobs with autoresubmission enabled, all jobs failed and you ran `sframe_batch.py` again (without `-l`), the jobs were re-submitted, but the state of the process remained "Failed". If you now tried to run `sframe_batch.py -l` (in loopCheck mode), it would always exit.

Now the status is set to "Working" as soon as jobs are resubmitted by the automatic resubmission.