### PR TITLE
Exit code 0 when (re)submit went OK, instead of job status

### DIFF
--- a/sframe_batch.py
+++ b/sframe_batch.py
@@ -237,6 +237,10 @@ def SFrameBatchMain(input_options):
     print "SFrame Batch was running for",round(stop - start,2),"sec"
     #exit gracefully
 
+    if (options.submit or options.resubmit):
+        # return code here indicates (re)submission went OK, not job statuses are all done
+        return 0
+
     if all(si.status == 1 for si in manager.subInfo):
         return 0
     else:


### PR DESCRIPTION
Currently the code always returns an exit code that depends on if Jobs have successfully finished. This isn't useful for job (re)submission, and returning 0 allows it to be used in other scripts without failing.