### PR TITLE
Fixes issue in job status check (introduced in last PR) 

### DIFF
--- a/Manager.py
+++ b/Manager.py
@@ -24,6 +24,8 @@ class pidWatcher(object):
     def __init__(self,subInfo):
         self.pidStates = {}
         ListOfPids = [subInfo[k].arrayPid for k in range(len(subInfo)) if subInfo[k].arrayPid > 0 ]
+        if(len(ListOfPids)==0):
+            return
         try:
             #looking into condor_q for jobs that are idle, running or hold (HTC State 1,2 and 5)
             proc_cQueue = subprocess.Popen(['condor_q']+ListOfPids+['-af:,','GlobalJobId','JobStatus'],stdout=subprocess.PIPE,stderr=subprocess.PIPE)

--- a/Manager.py
+++ b/Manager.py
@@ -23,7 +23,12 @@ import xml.sax
 class pidWatcher(object):
     def __init__(self,subInfo):
         self.pidStates = {}
-        ListOfPids = [subInfo[k].arrayPid for k in range(len(subInfo)) if subInfo[k].arrayPid > 0 ]
+        ListOfPids = [subInfo[k].arrayPid for k in range(len(subInfo)) if len(subInfo[k].arrayPid) > 0 ]
+        # adding Pids of resubmitted jobs
+        for process in subInfo:
+            for pid in process.pids:
+                if process.arrayPid not in pid:
+                    ListOfPids.append(pid)
         if(len(ListOfPids)==0):
             return
         try:
@@ -47,14 +52,9 @@ class pidWatcher(object):
             print 'Going to wait for 5 minutes, lets see if condor_q will start to work again.'
             time.sleep(300)
             return
-        if(any(i==-1 for i in ListOfPids)):
+        if(any(len(i)==0 for i in ListOfPids)):
             self.parserWorked=False
         if self.parserWorked:
-            # adding Pids of resubmitted jobs
-            for process in subInfo:
-                for pid in process.pids:
-                    if process.arrayPid not in pid:
-                        ListOfPids.append(pid)
             for item in processes_json:
                 raw_id = item["GlobalJobId"]
                 jobid = raw_id.split("#")[1]

--- a/SubmissionInfo_Class.py
+++ b/SubmissionInfo_Class.py
@@ -18,7 +18,7 @@ class SubInfo(object):
         self.reachedBatch = [False]*numberOfFiles
         self.jobsRunning = [False]*numberOfFiles
         self.jobsDone = [False]*numberOfFiles
-        self.arrayPid = -1
+        self.arrayPid = ''
         self.resubmit = [resubmit]*numberOfFiles
         self.startingTime = 0
     def reset_resubmit(self,value):


### PR DESCRIPTION
The default arrayPid is now an empty string `''` instead of an integer (-1).
Also now the status of resubmitted jobs is actually checked.