### PR TITLE
Bugfix: parserWorked was not declared

### DIFF
--- a/Manager.py
+++ b/Manager.py
@@ -30,6 +30,7 @@ class pidWatcher(object):
                 if process.arrayPid not in pid:
                     ListOfPids.append(pid)
         if(len(ListOfPids)==0):
+            self.parserWorked = False
             return
         try:
             #looking into condor_q for jobs that are idle, running or hold (HTC State 1,2 and 5)


### PR DESCRIPTION
 when ListOfPids is empty for some reason (e.g. when SubmissionInfo.p got deleted)  parserWorked boolean is now set to False