### PR TITLE
Option to force running on EL7 worker node; if SL6 arch, use singularity image

### DIFF
--- a/Manager.py
+++ b/Manager.py
@@ -111,6 +111,8 @@ class JobManager(object):
         self.keepGoing = options.keepGoing
         self.exitOnQuestion = options.exitOnQuestion
         self.outputstream = self.workdir+'/Stream_'
+        self.el7_worker = options.el7worker  # enforce running on EL7 mahcine
+
     #read xml file and do the magic 
     def process_jobs(self,InputData,Job):
         jsonhelper = HelpJSON(self.workdir+'/SubmissinInfoSave.p')
@@ -132,7 +134,7 @@ class JobManager(object):
             else:
                 self.totalFiles += self.subInfo[-1].numberOfFiles
                 self.subInfo[-1].reset_resubmit(self.header.AutoResubmit) #Reset the retries every time you start
-                write_script(processName[0],self.workdir,self.header) #Write the scripts you need to start the submission
+                write_script(processName[0],self.workdir,self.header,self.el7_worker) #Write the scripts you need to start the submission
         gc.enable()
     #submit the jobs to the batch as array job
     #the used function should soon return the pid of the job for killing and knowing if something failed
@@ -164,7 +166,7 @@ class JobManager(object):
                             exit(-1)
                     ask = False
                 if batchstatus != 1:
-                    process.pids[it-1] = resubmit(self.outputstream+process.name,process.name+'_'+str(it),self.workdir,self.header)
+                    process.pids[it-1] = resubmit(self.outputstream+process.name,process.name+'_'+str(it),self.workdir,self.header,self.el7_worker)
                     #print 'Resubmitted job',process.name,it, 'pid', process.pids[it-1]
                     self.printString.append('Resubmitted job '+process.name+' '+str(it)+' pid '+str(process.pids[it-1]))
                     if process.status != 0: process.status =0
@@ -224,7 +226,7 @@ class JobManager(object):
                         ask = False
                     #print 'resubmitting', process.name+'_'+str(it+1),es not Found',process.notFoundCounter[it], 'pid', process.pids[it], process.arrayPid, 'task',it+1
                     waitingFlag_autoresub = True
-                    process.pids[it] = resubmit(self.outputstream+process.name,process.name+'_'+str(it+1),self.workdir,self.header)
+                    process.pids[it] = resubmit(self.outputstream+process.name,process.name+'_'+str(it+1),self.workdir,self.header,self.el7_worker)
                     process.status = 0
                     #print 'AutoResubmitted job',process.name,it, 'pid', process.pids[it]
                     self.printString.append('File Found '+str(os.path.exists(filename)))

--- a/batch_classes.py
+++ b/batch_classes.py
@@ -9,6 +9,9 @@ from tree_checker import *
 #from fhadd import fhadd
 
 
+SINGULARITY_IMG = os.path.expandvars("/nfs/dust/cms/user/$USER/slc6_latest.sif")
+
+
 def write_script(name,workdir,header,el7_worker=False):
     sframe_wrapper=open(workdir+'/sframe_wrapper.sh','w')
 
@@ -40,7 +43,13 @@ sframe_main $1
         worker_str = 'Requirements = ( OpSysAndVer == "CentOS7" )\n'
         if 'slc6' in os.getenv('SCRAM_ARCH'):
             # Run a SLC6 job on EL7 machine using singularity
-            worker_str += '+MySingularityImage="/cvmfs/unpacked.cern.ch/registry.hub.docker.com/cmssw/slc6:latest"\n'
+            if not os.path.isfile(SINGULARITY_IMG):
+                print "Please pull the SLC6 image to your NFS:"
+                print ""
+                print 'SINGULARITY_CACHEDIR="/nfs/dust/cms/user/$USER/singularity" singularity pull /nfs/dust/cms/user/$USER/slc6_latest.sif docker://cmssw/slc6:latest'
+                print ""
+                raise RuntimeError("You should put your singularity image on /nfs, not /afs or /cvmfs.")
+            worker_str += '+MySingularityImage="'+SINGULARITY_IMG+'"\n'
 
     submit_file = open(workdir+'/CondorSubmitfile_'+name+'.submit','w')
     submit_file.write(
@@ -86,7 +95,7 @@ def resub_script(name,workdir,header,el7_worker=False):
         worker_str = 'Requirements = ( OpSysAndVer == "CentOS7" )\n'
         if 'slc6' in os.getenv('SCRAM_ARCH'):
             # Run a SLC6 job on EL7 machine using singularity
-            worker_str += '+MySingularityImage="/cvmfs/unpacked.cern.ch/registry.hub.docker.com/cmssw/slc6:latest"\n'
+            worker_str += '+MySingularityImage="'+SINGULARITY_IMG+'"\n'
 
     submitfile = open(workdir+'/CondorSubmitfile_'+name+'.submit','w')
     submitfile.write(

--- a/batch_classes.py
+++ b/batch_classes.py
@@ -33,7 +33,6 @@ def write_script(name,workdir,header,el7_worker=False):
 export LD_LIBRARY_PATH=$LD_LIBRARY_PATH_STORED:$LD_LIBRARY_PATH
 export PATH=$PATH_STORED:$PATH
 export SFRAME_TEMP_DIR="""+tmp_dir+"""
-mkdir -p ${SFRAME_TEMP_DIR}
 sframe_main $1
         """)
     sframe_wrapper.close()

--- a/batch_classes.py
+++ b/batch_classes.py
@@ -48,9 +48,9 @@ sframe_main $1
             if not os.path.isfile(SINGULARITY_IMG):
                 print "Please pull the SLC6 image to your NFS:"
                 print ""
-                print 'SINGULARITY_CACHEDIR="/nfs/dust/cms/user/$USER/singularity" singularity pull /nfs/dust/cms/user/$USER/slc6_latest.sif docker://cmssw/slc6:latest'
+                print 'SINGULARITY_CACHEDIR="/nfs/dust/cms/user/$USER/singularity" singularity pull', SINGULARITY_IMG, 'docker://cmssw/slc6:latest'
                 print ""
-                raise RuntimeError("You should put your singularity image on /nfs, not /afs or /cvmfs.")
+                raise RuntimeError("Cannot find image, %s. Do not use one from /afs or /cvmfs." % SINGULARITY_IMG)
             worker_str += '+MySingularityImage="'+SINGULARITY_IMG+'"\n'
     else:
         # Choose worker node arch based on SCRAM_ARCH (not login node arch)

--- a/batch_classes.py
+++ b/batch_classes.py
@@ -17,10 +17,11 @@ def write_script(name,workdir,header,el7_worker=False):
 
     # For some reason, we have to manually copy across certain environment
     # variables, most notably LD_LIBRARY_PATH, and if running on singularity, PATH
+    # Note that we need the existing PATH, otherwise it loses basename, sed, etc
     sframe_wrapper.write(
         """#!/bin/bash
 export LD_LIBRARY_PATH=$LD_LIBRARY_PATH_STORED
-export PATH=$PATH_STORED
+export PATH=$PATH_STORED:$PATH
 sframe_main $1
         """)
     sframe_wrapper.close()

--- a/batch_classes.py
+++ b/batch_classes.py
@@ -103,6 +103,12 @@ def resub_script(name,workdir,header,el7_worker=False):
         worker_str = 'Requirements = ( OpSysAndVer == "CentOS7" )\n'
         if 'slc6' in os.getenv('SCRAM_ARCH'):
             # Run a SLC6 job on EL7 machine using singularity
+            if not os.path.isfile(SINGULARITY_IMG):
+                print "Please pull the SLC6 image to your NFS:"
+                print ""
+                print 'SINGULARITY_CACHEDIR="/nfs/dust/cms/user/$USER/singularity" singularity pull', SINGULARITY_IMG, 'docker://cmssw/slc6:latest'
+                print ""
+                raise RuntimeError("Cannot find image, %s. Do not use one from /afs or /cvmfs." % SINGULARITY_IMG)
             worker_str += '+MySingularityImage="'+SINGULARITY_IMG+'"\n'
     else:
         if 'slc7' in os.getenv('SCRAM_ARCH'):

--- a/sframe_batch.py
+++ b/sframe_batch.py
@@ -102,6 +102,10 @@ def SFrameBatchMain(input_options):
                       dest="xmldatabaseDir",
                       help="This command creates from a data file the new sframe_main xml file calculating the lumi from the number of events and a given cross section. You can specify the number of events (weighted). Else it will try to find the number of events at the end of the xml Files (stored in the dateset directory) or use a small python script to read the number of entries from the trees. If it has to read the number of entries from the trees you need to specify how many cores it should use and also the method to be used. True == Fast / False == weights. Example can be found as DatabaseExample. USERCONFIG is not filled and needs to be done manually. Usage: sframe_batch --XMLDatabase DATABASE_DIR FILENAME_TO_STORE."
                       )
+    parser.add_option("--el7worker",
+                      action='store_true',
+                      help='Force job to be run on EL7 node. '
+                      'If SLC6 environment, will use singularity.')
 
 
     (options, args) = parser.parse_args(input_options)


### PR DESCRIPTION
Add `--el7worker` option. This enforces running on a EL7 worker node, irrespective of what is in `SCRAM_ARCH` or which login arch you are using. 

If `SCRAM_ARCH` is a `slc6` one, it will add the necessary singularity image to the condor job file. Note that it assumes one exists in the user's area as `/nfs/dust/cms/user/$USER/slc6_latest.sif`. This is because I found that using the CVMFS one en masse would break - it's far more stable to use one that the user has pulled to their area. I have added instructions to the error if the user hasn't pulled the image yet.

(BTW I couldn't find a nicer way to pass this option to `write_script()`... let me know if there is one)

Without the `--el7worker` option, it defaults to choosing worker node arch based on `SCRAM_ARCH`. 

Aside: to open a shell in the image locally, do:

```
singularity shell --bind /afs:/afs:rw --bind /nfs:/nfs:rw --bind /pnfs:/pnfs:ro --bind /cvmfs:/cvmfs:ro /nfs/dust/cms/user/$USER/slc6_latest.sif
```

no access to `condor_*` commands though.