### PR TITLE
added option to xmllint execution

### DIFF
--- a/sframe_batch.py
+++ b/sframe_batch.py
@@ -145,7 +145,7 @@ def SFrameBatchMain(input_options):
         os.system('ln -sf %s/JobConfig.dtd .' % scriptpath)
 
     #print xmlfile, os.getcwd
-    proc_xmllint = subprocess.Popen(['xmllint','--noent',xmlfile],stdout=subprocess.PIPE)
+    proc_xmllint = subprocess.Popen(['xmllint','--noent','--dtdattr',xmlfile],stdout=subprocess.PIPE)
     xmlfile_strio = StringIO.StringIO(proc_xmllint.communicate()[0])
     sax_parser = xml.sax.make_parser()
     xmlparsed = parse(xmlfile_strio,sax_parser)


### PR DESCRIPTION
This adds the option `--dtdattr` to the execution of `xmllint` when sframe_batch initially takes a look at the specified input xml.

This options ensures that the external DTD (commonly `JobConfig.dtd` in analysts config directory) is fetched and any specified entities are loaded.