### PR TITLE
Fixed OS-Requirement (CentOS 7) and Singularity option for SL6

### DIFF
--- a/Manager.py
+++ b/Manager.py
@@ -111,7 +111,7 @@ class JobManager(object):
         self.keepGoing = options.keepGoing
         self.exitOnQuestion = options.exitOnQuestion
         self.outputstream = self.workdir+'/Stream_'
-        self.el7_worker = options.el7worker  # enforce running on EL7 mahcine
+        self.sl6_container = options.sl6container  # run code in SL6 singularity container
 
     #read xml file and do the magic 
     def process_jobs(self,InputData,Job):
@@ -134,7 +134,7 @@ class JobManager(object):
             else:
                 self.totalFiles += self.subInfo[-1].numberOfFiles
                 self.subInfo[-1].reset_resubmit(self.header.AutoResubmit) #Reset the retries every time you start
-                write_script(processName[0],self.workdir,self.header,self.el7_worker) #Write the scripts you need to start the submission
+                write_script(processName[0],self.workdir,self.header,self.sl6_container) #Write the scripts you need to start the submission
         gc.enable()
     #submit the jobs to the batch as array job
     #the used function should soon return the pid of the job for killing and knowing if something failed
@@ -226,7 +226,7 @@ class JobManager(object):
                         ask = False
                     #print 'resubmitting', process.name+'_'+str(it+1),es not Found',process.notFoundCounter[it], 'pid', process.pids[it], process.arrayPid, 'task',it+1
                     waitingFlag_autoresub = True
-                    process.pids[it] = resubmit(self.outputstream+process.name,process.name+'_'+str(it+1),self.workdir,self.header,self.el7_worker)
+                    process.pids[it] = resubmit(self.outputstream+process.name,process.name+'_'+str(it+1),self.workdir,self.header,self.sl6_container)
                     process.status = 0
                     #print 'AutoResubmitted job',process.name,it, 'pid', process.pids[it]
                     self.printString.append('File Found '+str(os.path.exists(filename)))

--- a/Manager.py
+++ b/Manager.py
@@ -166,7 +166,7 @@ class JobManager(object):
                             exit(-1)
                     ask = False
                 if batchstatus != 1:
-                    process.pids[it-1] = resubmit(self.outputstream+process.name,process.name+'_'+str(it),self.workdir,self.header,self.el7_worker)
+                    process.pids[it-1] = resubmit(self.outputstream+process.name,process.name+'_'+str(it),self.workdir,self.header,self.sl6_container)
                     #print 'Resubmitted job',process.name,it, 'pid', process.pids[it-1]
                     self.printString.append('Resubmitted job '+process.name+' '+str(it)+' pid '+str(process.pids[it-1]))
                     if process.status != 0: process.status =0

--- a/batch_classes.py
+++ b/batch_classes.py
@@ -42,7 +42,7 @@ sframe_main $1
 
     #Make sure user does not try to submit jobs to the EL7 nodes without singularity from a environment with a SL6 SCRAM_ARCH
     if 'slc6' in os.getenv("SCRAM_ARCH") and not sl6_container:
-        raise EnvironmentError("\033[91mSCRAM_ARCH shows this environment is setup for SL6. You tried to submit to EL7 nodes without using a singularity.\n Make sure to use --sl6container to run these jobs inside singularity container.\033[0m")
+        raise EnvironmentError("\033[91mSCRAM_ARCH shows this environment is setup for SL6. You tried to submit to EL7 nodes without using a singularity container.\n Make sure to use --sl6container to run these jobs inside singularity container.\033[0m")
 
     worker_str = ""
     # Run a SLC6 job on EL7 machine using singularity
@@ -102,7 +102,7 @@ def resub_script(name,workdir,header,sl6_container=False):
 
     #Make sure user does not try to submit jobs to the EL7 nodes without singularity from a environment with a SL6 SCRAM_ARCH
     if 'slc6' in os.getenv("SCRAM_ARCH") and not sl6_container:
-        raise EnvironmentError("\033[91mSCRAM_ARCH shows this environment is setup for SL6. You tried to submit to EL7 nodes without using a singularity.\n Make sure to use --sl6container to run these jobs inside singularity container.\033[0m")
+        raise EnvironmentError("\033[91mSCRAM_ARCH shows this environment is setup for SL6. You tried to submit to EL7 nodes without using a singularity container.\n Make sure to use --sl6container to run these jobs inside singularity container.\033[0m")
     
     worker_str = ""
     # Run a SLC6 job on EL7 machine using singularity

--- a/batch_classes.py
+++ b/batch_classes.py
@@ -36,7 +36,8 @@ sframe_main $1
     else:
         condor_notification = ''
 
-    if(os.path.isfile(workdir+'/CondorSubmitfile_'+name+'.submit')):
+    condor_submitfile_name = workdir+'/CondorSubmitfile_'+name+'.submit'
+    if(os.path.isfile(condor_submitfile_name)):
         return
 
     #Make sure user does not try to submit jobs to the EL7 nodes without singularity from a environment with a SL6 SCRAM_ARCH
@@ -55,7 +56,7 @@ sframe_main $1
         worker_str += '+MySingularityImage="'+SINGULARITY_IMG+'"\n'
         worker_str += '+MySingularityArgs="--bind /tmp:/tmp"\n'
 
-    submit_file = open(workdir+'/CondorSubmitfile_'+name+'.submit','w')
+    submit_file = open(condor_submitfile_name,'w')
     submit_file.write(
         """#HTC Submission File for SFrameBatch
 # +MyProject        =  "af-cms"
@@ -95,7 +96,8 @@ def resub_script(name,workdir,header,sl6_container=False):
     else:
         condor_notification = ''
 
-    if(os.path.isfile(workdir+'/CondorSubmitfile_'+name+'.submit')):
+    condor_resubmitfile_name = workdir+'/CondorSubmitfile_'+name+'.submit'
+    if(os.path.isfile(condor_resubmitfile_name)):
         return
 
     #Make sure user does not try to submit jobs to the EL7 nodes without singularity from a environment with a SL6 SCRAM_ARCH
@@ -114,7 +116,7 @@ def resub_script(name,workdir,header,sl6_container=False):
         worker_str += '+MySingularityImage="'+SINGULARITY_IMG+'"\n'
         worker_str += '+MySingularityArgs="--bind /tmp:/tmp"\n'
 
-    submitfile = open(workdir+'/CondorSubmitfile_'+name+'.submit','w')
+    submitfile = open(condor_resubmitfile_name,'w')
     submitfile.write(
 """#HTC Submission File for SFrameBatch
 # +MyProject        =  "af-cms"

--- a/batch_classes.py
+++ b/batch_classes.py
@@ -12,7 +12,7 @@ from tree_checker import *
 SINGULARITY_IMG = os.path.expandvars("/nfs/dust/cms/user/$USER/slc6_latest.sif")
 
 
-def write_script(name,workdir,header,el7_worker=False):
+def write_script(name,workdir,header,sl6_container=False):
     sframe_wrapper=open(workdir+'/sframe_wrapper.sh','w')
 
     # For some reason, we have to manually copy across certain environment
@@ -36,36 +36,30 @@ sframe_main $1
     else:
         condor_notification = ''
 
-    # Note that it automatically figures out which worker node arch you need
-    # based on submit node arch.
-    # However we don't always want this.
-    # We can enforce a EL7 worker, and if necessary load a SL6 singularity image.
-    # Or we just take the desired worker node arch from SCRAM_ARCH
-    # (such that one can submit SLC6 worker node jobs from a EL7 node)
+    if(os.path.isfile(workdir+'/CondorSubmitfile_'+name+'.submit')):
+        return
+
+    #Make sure user does not try to submit jobs to the EL7 nodes without singularity from a environment with a SL6 SCRAM_ARCH
+    if 'slc6' in os.getenv("SCRAM_ARCH") and not sl6_container:
+        raise EnvironmentError("\033[91mSCRAM_ARCH shows this environment is setup for SL6. You tried to submit to EL7 nodes without using a singularity.\n Make sure to use --sl6container to run these jobs inside singularity container.\033[0m")
+
     worker_str = ""
-    if el7_worker:
-        worker_str = 'Requirements = ( OpSysAndVer == "CentOS7" )\n'
-        if 'slc6' in os.getenv('SCRAM_ARCH'):
-            # Run a SLC6 job on EL7 machine using singularity
-            if not os.path.isfile(SINGULARITY_IMG):
-                print "Please pull the SLC6 image to your NFS:"
-                print ""
-                print 'SINGULARITY_CACHEDIR="/nfs/dust/cms/user/$USER/singularity" singularity pull', SINGULARITY_IMG, 'docker://cmssw/slc6:latest'
-                print ""
-                raise RuntimeError("Cannot find image, %s. Do not use one from /afs or /cvmfs." % SINGULARITY_IMG)
-            worker_str += '+MySingularityImage="'+SINGULARITY_IMG+'"\n'
-            worker_str += '+MySingularityArgs="--bind /tmp:/tmp"\n'
-    else:
-        # Choose worker node arch based on SCRAM_ARCH (not login node arch)
-        if 'slc7' in os.getenv('SCRAM_ARCH'):
-            worker_str = 'Requirements = ( OpSysAndVer == "CentOS7" )'
-        else:
-            worker_str = 'Requirements = ( OpSysAndVer == "SL6" )'
+    # Run a SLC6 job on EL7 machine using singularity
+    if sl6_container:
+        if not os.path.isfile(SINGULARITY_IMG):
+            print '\033[93m',"Please pull the SLC6 image to your NFS:",'\033[0m'
+            print ""
+            print '\033[93m','SINGULARITY_CACHEDIR="/nfs/dust/cms/user/$USER/singularity" singularity pull', SINGULARITY_IMG, 'docker://cmssw/slc6:latest','\033[0m'
+            print ""
+            raise RuntimeError("\033[91mCannot find image, %s. Do not use one from /afs or /cvmfs.\033[0m" % SINGULARITY_IMG)
+        worker_str += '+MySingularityImage="'+SINGULARITY_IMG+'"\n'
+        worker_str += '+MySingularityArgs="--bind /tmp:/tmp"\n'
 
     submit_file = open(workdir+'/CondorSubmitfile_'+name+'.submit','w')
     submit_file.write(
         """#HTC Submission File for SFrameBatch
 # +MyProject        =  "af-cms"
+Requirements = ( OpSysAndVer == "CentOS7" )
 """ + worker_str + """
 universe          = vanilla
 # #Running in local mode with 8 cpu slots
@@ -91,7 +85,7 @@ arguments         = """+name+"""_$(fileindex).xml
 """)
     submit_file.close()
 
-def resub_script(name,workdir,header,el7_worker=False):
+def resub_script(name,workdir,header,sl6_container=False):
     if (header.Notification == 'as'):
         condor_notification = 'Error'
     elif (header.Notification == 'n'):
@@ -101,28 +95,30 @@ def resub_script(name,workdir,header,el7_worker=False):
     else:
         condor_notification = ''
 
+    if(os.path.isfile(workdir+'/CondorSubmitfile_'+name+'.submit')):
+        return
+
+    #Make sure user does not try to submit jobs to the EL7 nodes without singularity from a environment with a SL6 SCRAM_ARCH
+    if 'slc6' in os.getenv("SCRAM_ARCH") and not sl6_container:
+        raise EnvironmentError("\033[91mSCRAM_ARCH shows this environment is setup for SL6. You tried to submit to EL7 nodes without using a singularity.\n Make sure to use --sl6container to run these jobs inside singularity container.\033[0m")
+    
     worker_str = ""
-    if el7_worker:
-        worker_str = 'Requirements = ( OpSysAndVer == "CentOS7" )\n'
-        if 'slc6' in os.getenv('SCRAM_ARCH'):
-            # Run a SLC6 job on EL7 machine using singularity
-            if not os.path.isfile(SINGULARITY_IMG):
-                print "Please pull the SLC6 image to your NFS:"
-                print ""
-                print 'SINGULARITY_CACHEDIR="/nfs/dust/cms/user/$USER/singularity" singularity pull', SINGULARITY_IMG, 'docker://cmssw/slc6:latest'
-                print ""
-                raise RuntimeError("Cannot find image, %s. Do not use one from /afs or /cvmfs." % SINGULARITY_IMG)
-            worker_str += '+MySingularityImage="'+SINGULARITY_IMG+'"\n'
-    else:
-        if 'slc7' in os.getenv('SCRAM_ARCH'):
-            worker_str = 'Requirements = ( OpSysAndVer == "CentOS7" )'
-        else:
-            worker_str = 'Requirements = ( OpSysAndVer == "SL6" )'
+    # Run a SLC6 job on EL7 machine using singularity
+    if sl6_container:
+        if not os.path.isfile(SINGULARITY_IMG):
+            print '\033[93m',"Please pull the SLC6 image to your NFS:",'\033[0m'
+            print ""
+            print '\033[93m','SINGULARITY_CACHEDIR="/nfs/dust/cms/user/$USER/singularity" singularity pull', SINGULARITY_IMG, 'docker://cmssw/slc6:latest','\033[0m'
+            print ""
+            raise RuntimeError("\033[91mCannot find image, %s. Do not use one from /afs or /cvmfs.\033[0m" % SINGULARITY_IMG)
+        worker_str += '+MySingularityImage="'+SINGULARITY_IMG+'"\n'
+        worker_str += '+MySingularityArgs="--bind /tmp:/tmp"\n'
 
     submitfile = open(workdir+'/CondorSubmitfile_'+name+'.submit','w')
     submitfile.write(
 """#HTC Submission File for SFrameBatch
 # +MyProject        =  "af-cms"
+Requirements = ( OpSysAndVer == "CentOS7" )
 """ + worker_str + """
 universe          = vanilla
 # #Running in local mode with 8 cpu slots
@@ -163,9 +159,9 @@ def submit_qsub(NFiles,Stream,name,workdir):
     return (proc_qstat.communicate()[0].split()[7]).split('.')[0]
 
 
-def resubmit(Stream,name,workdir,header,el7_worker):
+def resubmit(Stream,name,workdir,header,sl6_container):
     #print Stream ,name
-    resub_script(name,workdir,header,el7_worker)
+    resub_script(name,workdir,header,sl6_container)
     if not os.path.exists(Stream):
         os.makedirs(Stream)
         print Stream+' has been created'

--- a/sframe_batch.py
+++ b/sframe_batch.py
@@ -110,8 +110,13 @@ def SFrameBatchMain(input_options):
                       help='Use singularity to run inside SL6-container on EL7-Nodes.')
 
     (options, args) = parser.parse_args(input_options)
+
     if(options.el7worker):
-        options.sl6container = True        
+        options.sl6container = True
+        import warnings
+        warnings.simplefilter("once", DeprecationWarning)
+        warnings.warn("\033[93m\nYou are using the option --el7worker, which will be removed soon. Although this still works, you should consider to switch to the option --sl6container, if you want to run jobs inside a SL6-container on EL7 HTCondor machines using singularity.\n\033[0m", DeprecationWarning)
+        
     start = timeit.default_timer()
 
     if 'missing_files.txt' in args[0]:

--- a/sframe_batch.py
+++ b/sframe_batch.py
@@ -104,12 +104,14 @@ def SFrameBatchMain(input_options):
                       )
     parser.add_option("--el7worker",
                       action='store_true',
-                      help='Force job to be run on EL7 node. '
-                      'If SLC6 environment, will use singularity.')
-
+                      help='Use singularity to run inside SL6-container on EL7-Nodes.')
+    parser.add_option("--sl6container",
+                      action='store_true',
+                      help='Use singularity to run inside SL6-container on EL7-Nodes.')
 
     (options, args) = parser.parse_args(input_options)
-    
+    if(options.el7worker):
+        options.sl6container = True        
     start = timeit.default_timer()
 
     if 'missing_files.txt' in args[0]:


### PR DESCRIPTION
This PR takes care of necessary things in the wake of SL6 EOL (30.11.2020).
It updates the OS-Requirements in the HTCondor submission file to be always `CentOS7`.

Also in case one wants to keep using SL6 inside a singularity container this is still possible by using the option `--el7worker`.
Since this option is not the active part in forcing the submission to EL7 nodes anymore (i.e. the name is maybe misleading), i added the option `--sl6container`, which does the same and is intended to stick around in the future.
Using either option is mandatory when submitting from an environment with `SCRAM_ARCH=slc6*` and doing otherwise will raise an exception.