### PR TITLE
switched to TFile.Open to be able to use xRootd

### DIFF
--- a/io_func.py
+++ b/io_func.py
@@ -163,7 +163,7 @@ def get_number_of_events(Job, Version, atleastOneEvent = False):
     for entry in InputData.io_list.FileInfoList[:]:
             for name in entry:
                 if name.endswith('.root'):
-                    f = ROOT.TFile(name)
+                    f = ROOT.TFile.Open(name)
                     try:
                         n = f.Get(str(InputData.io_list.InputTree[2])).GetEntriesFast()
                         if n < 1:


### PR DESCRIPTION
This just switches the way the ntuple files are opened in the splitting process, where the Number of Events is counted.

In pyRoot opening a file via xrootd using `ROOT.TFile("filename")` does not work, while `ROOT.TFile("filename")` works for both accessing "local" files and remote files via xrootd.