### PR TITLE
stripping whitespace from filename

### DIFF
--- a/io_func.py
+++ b/io_func.py
@@ -162,7 +162,7 @@ def get_number_of_events(Job, Version, atleastOneEvent = False):
         atleastOneEvent=False
     for entry in InputData.io_list.FileInfoList[:]:
             for name in entry:
-                if name.endswith('.root'):
+                if name.strip().endswith('.root'):
                     f = ROOT.TFile.Open(name)
                     try:
                         n = f.Get(str(InputData.io_list.InputTree[2])).GetEntriesFast()


### PR DESCRIPTION
Small addition to `io_func.py` in order to strip unwanted whitespace from filenames.
With unwanted whitespace at the end of the filename sframe_batch will just think the file has 0 Events/no InputTree.
